### PR TITLE
Do not send leave room event if the client hasn't joined

### DIFF
--- a/client/src/containers/Room/Room.js
+++ b/client/src/containers/Room/Room.js
@@ -75,7 +75,9 @@ class Room extends Component {
 
   // Leave the room
   componentWillUnmount() {
-    this.socket.emit('leave room');
+    if (this.room && this.room.id !== undefined) {
+      this.socket.emit('leave room');
+    }
   }
 
   // On send

--- a/index.js
+++ b/index.js
@@ -114,10 +114,14 @@ io.on('connection', socket => {
   socket.on('leave room', () => {
     let user = users[socket.id];
     console.log('User left room: ' + user.room.id);
-    socket.leave(user.room.id);
-    topics.leaveRoom(user.room.topic, user.room.id, socket.id);
-    // Emit new user
-    io.sockets.in(user.room.id).emit('user leave', user.client);
+
+    if (user && user.room && user.room.id !== undefined) {
+      socket.leave(user.room.id);
+      topics.leaveRoom(user.room.topic, user.room.id, socket.id);
+
+      // Emit new user
+      io.sockets.in(user.room.id).emit('user leave', user.client);
+    }
   });
 
   socket.on('send message', (data) => {


### PR DESCRIPTION
Fixes #12 

There were two issues present here:
1) The Room container was programed to send a `leave room` event on `componentWillUnmount`. It also redirects to `join` when the client hasn't joined a room, so it was sending the `leave room` event without even being in the room in the first place.

2) The server wasn't checking if the room and room.id properties existed in the user object, so it was sending undefined values to `leaveRoom`. I feel like we should still improve this and check if the room about to be left exists and stuff like that. I would suggest we create a different PR where we improve all that code to improve the safety of the operations.